### PR TITLE
refactor: staff-schedule

### DIFF
--- a/libs/calendar/src/event/factories/event.factory.ts
+++ b/libs/calendar/src/event/factories/event.factory.ts
@@ -4,6 +4,7 @@ import { Event, EventStatus } from '../entities/event.entity';
 import { EventType } from '../entities/event-type.enum';
 import { StaffSchedule } from 'src/modules/staff-schedule/entities/staff-schedule.entity';
 import { RecurrenceParser } from '@calendar/calendar/utils/recurrence-parser';
+import { formatInTimeZone } from 'date-fns-tz';
 
 @Injectable()
 export class EventFactory {
@@ -66,7 +67,13 @@ export class EventFactory {
         staffSchedule.daysOfWeek
       );
       
-      return dates.map(date => {
+      // Filtrar excepciones
+      const filteredDates = dates.filter(date => {
+        const dateString = formatInTimeZone(date, 'America/Lima', 'yyyy-MM-dd');
+        return !staffSchedule.exceptions.includes(dateString);
+      });
+
+      return filteredDates.map(date => {
         const event = new Event();
         Object.assign(event, {...baseEvent});
         

--- a/libs/calendar/src/utils/recurrence-parser.ts
+++ b/libs/calendar/src/utils/recurrence-parser.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { addDays, eachWeekOfInterval, parse, setHours, setMinutes, startOfDay, endOfDay, isValid, lastDayOfMonth } from 'date-fns';
+import { addDays, eachWeekOfInterval, setHours, setMinutes, startOfDay, endOfDay, isValid, lastDayOfMonth } from 'date-fns';
 import { formatInTimeZone, toDate } from 'date-fns-tz';
 import { es } from 'date-fns/locale';
 
@@ -45,7 +45,7 @@ export class RecurrenceParser {
       try {
         // Primero intentamos crear la fecha normalmente
         parsedUntilDate = new Date(year, month - 1, day);
-        
+
         // Si la fecha no es válida (como 31 de febrero), usamos el último día del mes
         if (!isValid(parsedUntilDate)) {
           parsedUntilDate = lastDayOfMonth(new Date(year, month - 1, 1));
@@ -59,7 +59,6 @@ export class RecurrenceParser {
         parsedStartDate: startDate.toISOString(),
         parsedUntilDate: parsedUntilDate.toISOString()
       });
-
       // Convertir fechas a la zona horaria correcta
       const localStartDate = toDate(startDate, { timeZone: TIMEZONE });
       const untilDate = toDate(endOfDay(parsedUntilDate), { timeZone: TIMEZONE });
@@ -82,7 +81,7 @@ export class RecurrenceParser {
       weeks.forEach(week => {
         weekDayNumbers.forEach(dayNumber => {
           const date = addDays(week, dayNumber);
-          
+
           if (date >= localStartDate && date <= untilDate) {
             const eventDate = toDate(
               setMinutes(
@@ -101,7 +100,6 @@ export class RecurrenceParser {
           }
         });
       });
-
       this.logger.debug(`Total de fechas generadas: ${dates.length}`);
 
       return dates;

--- a/prisma/migrations/20250205172853_a/migration.sql
+++ b/prisma/migrations/20250205172853_a/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "StaffSchedule" ALTER COLUMN "exceptions" SET DATA TYPE TEXT[];

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -624,7 +624,7 @@ model StaffSchedule {
   endTime    String // Formato "HH:mm" (17:00)
   daysOfWeek DayOfWeek[] // Días de aplicación
   recurrence Json // { frequency: "WEEKLY", interval: 1, until: "2024-12-31", count: 10 }
-  exceptions DateTime[] // Fechas excluidas
+  exceptions String[] // Cambiar de DateTime[] a String[] para aceptar fechas en formato YYYY-MM-DD
   isActive   Boolean     @default(true)
   events     Event[] // Eventos generados
   staff      Staff       @relation(fields: [staffId], references: [id])

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,9 +27,10 @@ async function bootstrap() {
 
   app.useGlobalPipes(
     new ValidationPipe({
-      whitelist: true,
-      forbidNonWhitelisted: true,
       transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
     }),
   );
 

--- a/src/modules/staff-schedule/dto/update-staff-schedule.dto.ts
+++ b/src/modules/staff-schedule/dto/update-staff-schedule.dto.ts
@@ -1,8 +1,26 @@
-import { PartialType } from '@nestjs/swagger';
+import { PartialType, PickType } from '@nestjs/swagger';
 import { CreateStaffScheduleDto } from './create-staff-schedule.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
 /**
  * DTO para actualizar un horario del personal.
  * Extiende de CreateStaffScheduleDto de forma parcial.
  */
-export class UpdateStaffScheduleDto extends PartialType(CreateStaffScheduleDto) {} 
+export class UpdateStaffScheduleDto extends PartialType(
+  PickType(CreateStaffScheduleDto, [
+    'staffId',
+    'branchId',
+    'startTime',
+    'endTime',
+    'daysOfWeek',
+    'recurrence',
+    'exceptions'
+  ] as const)
+) {
+  @ApiProperty({
+    description: 'Título del horario (requerido)',
+    example: 'Turno Mañana',
+    required: true
+  })
+  title!: string; // Campo obligatorio
+} 

--- a/src/modules/staff-schedule/entities/staff-schedule.entity.ts
+++ b/src/modules/staff-schedule/entities/staff-schedule.entity.ts
@@ -43,15 +43,17 @@ export class StaffSchedule {
     description: 'Configuración de recurrencia',
     example: { frequency: 'WEEKLY', interval: 1, until: '2024-12-31' }
   })
-  recurrence: Record<string, any>;
+  recurrence: {
+    frequency: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY';
+    interval: number;
+    until: string;
+  };
 
   @ApiProperty({ 
-    description: 'Fechas excluidas del horario',
-    type: [Date],
-    required: false,
-    default: []
+    description: 'Fechas excluidas en formato YYYY-MM-DD',
+    example: ['2024-05-01']
   })
-  exceptions: Date[];
+  exceptions: string[];
 
   @ApiProperty({ default: true })
   isActive: boolean;

--- a/src/modules/staff-schedule/services/staff-schedule.service.ts
+++ b/src/modules/staff-schedule/services/staff-schedule.service.ts
@@ -63,13 +63,22 @@ export class StaffScheduleService {
   }
 
   /**
-   * Obtiene la lista de todos los horarios del personal.
-   * @returns Lista de horarios
+   * Obtiene la lista de todos los horarios del personal con información básica del staff
+   * @returns Lista de horarios con nombre y apellido del staff
    * @throws Lanza un error en caso de fallo al obtener los datos
    */
   async findAll(): Promise<StaffSchedule[]> {
     try {
-      return await this.staffScheduleRepository.findMany();
+      return await this.staffScheduleRepository.findMany({
+        include: {
+          staff: {
+            select: {
+              name: true,
+              lastName: true
+            }
+          }
+        }
+      });
     } catch (error) {
       this.errorHandler.handleError(error, 'getting');
     }


### PR DESCRIPTION
Se modifico el dto de create staffschedule y la entidad para recibir fechas en formato string en vez de date y en el front se manejan las fechas con la libreria date-fns