### PR TITLE
feat: Añadir método de actualización especial para personal con manej…

### DIFF
--- a/libs/staff/use-cases/update-staff.use-case.ts
+++ b/libs/staff/use-cases/update-staff.use-case.ts
@@ -19,7 +19,7 @@ export class UpdateStaffUseCase {
     private readonly staffRepository: StaffRepository,
     private readonly staffTypeRepository: StaffTypeRepository,
     private readonly auditService: AuditService,
-  ) {}
+  ) { }
 
   /**
    * Valida si ya existe personal con el DNI proporcionado, excluyendo al personal actual
@@ -63,7 +63,7 @@ export class UpdateStaffUseCase {
     }
 
     const updatedStaff = await this.staffRepository.transaction(async () => {
-      const staff = await this.staffRepository.update(id, updateStaffDto);
+      const staff = await this.staffRepository.updateStaff(id, updateStaffDto);
 
       // Registrar auditoría
       await this.auditService.create({


### PR DESCRIPTION
…o de relaciones nulas

- Implementar método updateStaff en repositorio de personal
- Agregar manejo explícito de campos nulos como userId, cmp y branchId
- Soportar conexión y desconexión de relaciones con branch y staffType
- Actualizar caso de uso de actualización de personal para usar nuevo método