### PR TITLE
feat: Mejorar la obtención de horarios del personal

### DIFF
--- a/src/modules/staff-schedule/repositories/staff-schedule.repository.ts
+++ b/src/modules/staff-schedule/repositories/staff-schedule.repository.ts
@@ -19,7 +19,22 @@ export class StaffScheduleRepository extends BaseRepository<StaffSchedule> {
    * @internal
    */
   async findStaffScheduleById(id: string): Promise<StaffSchedule> {
-    const schedule = await this.findById(id);
+    const schedule = await this.findOne({
+      where: { id },
+      include: {
+        staff: {
+          select: {
+            name: true,
+            lastName: true
+          }
+        },
+        branch: {
+          select: {
+            name: true
+          }
+        }
+      }
+    });
     if (!schedule) {
       throw new BadRequestException('Horario del personal no encontrado');
     }

--- a/src/modules/staff-schedule/services/staff-schedule.service.ts
+++ b/src/modules/staff-schedule/services/staff-schedule.service.ts
@@ -65,22 +65,13 @@ export class StaffScheduleService {
   }
 
   /**
-   * Obtiene la lista de todos los horarios del personal con información básica del staff
-   * @returns Lista de horarios con nombre y apellido del staff
+   * Obtiene la lista de todos los horarios del personal con información básica del staff y la sucursal
+   * @returns Lista de horarios con nombre y apellido del staff y nombre de la sucursal
    * @throws Lanza un error en caso de fallo al obtener los datos
    */
   async findAll(): Promise<StaffSchedule[]> {
     try {
-      return await this.staffScheduleRepository.findMany({
-        include: {
-          staff: {
-            select: {
-              name: true,
-              lastName: true
-            }
-          }
-        }
-      });
+      return await this.staffScheduleRepository.findWithRelations();
     } catch (error) {
       this.errorHandler.handleError(error, 'getting');
     }


### PR DESCRIPTION
- Actualizar el método findStaffScheduleById para incluir información del staff y la sucursal.
- Modificar el método findAll para utilizar findWithRelations, mejorando la consulta de horarios con datos adicionales del personal y la sucursal.

fixes digitales-2024/front-juan-pablo-ii#156