### PR TITLE
feat: Refactorizar módulos de eventos y horarios del personal

### DIFF
--- a/libs/calendar/src/event/events.module.ts
+++ b/libs/calendar/src/event/events.module.ts
@@ -2,7 +2,7 @@ import { AuditModule } from "@login/login/admin/audit/audit.module";
 import { EventRepository } from "./repositories/event.repository";
 import { EventService } from "./services/event.service";
 import { CreateEventUseCase } from "./use-cases/create-event.use-case";
-import { ClassSerializerInterceptor, Module } from "@nestjs/common";
+import { ClassSerializerInterceptor, Module, forwardRef } from "@nestjs/common";
 import { EventController } from "./controllers/event.controller";
 import { UpdateEventUseCase } from "./use-cases";
 import { DeleteEventsUseCase } from "./use-cases/delete-events.use-case";
@@ -25,7 +25,7 @@ import { PrismaModule } from "@prisma/prisma";
 @Module({
   imports: [
     AuditModule,
-    StaffScheduleModule,
+    forwardRef(() => StaffScheduleModule),
     PrismaModule,
   ],
   providers: [
@@ -48,6 +48,6 @@ import { PrismaModule } from "@prisma/prisma";
     },
   ],
   controllers: [EventController],
-  exports: [EventService],
+  exports: [EventService, EventRepository],
 })
 export class EventsModule { }

--- a/src/modules/staff-schedule/dto/create-staff-schedule.dto.ts
+++ b/src/modules/staff-schedule/dto/create-staff-schedule.dto.ts
@@ -15,7 +15,7 @@ import {
 import { Transform, Type } from 'class-transformer';
 import { DayOfWeek } from '@prisma/client';
 
-class RecurrenceDto {
+export class RecurrenceDto {
   @ApiProperty({
     description: 'Frecuencia de recurrencia',
     enum: ['DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'],

--- a/src/modules/staff-schedule/dto/update-staff-schedule.dto.ts
+++ b/src/modules/staff-schedule/dto/update-staff-schedule.dto.ts
@@ -1,27 +1,105 @@
-import { PartialType, PickType } from '@nestjs/swagger';
-import { CreateStaffScheduleDto } from './create-staff-schedule.dto';
 import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsOptional, IsArray, IsEnum, IsObject, ValidateNested, IsISO8601 } from 'class-validator';
+import { Transform, Type } from 'class-transformer';
+import { DayOfWeek } from '@prisma/client';
+import { RecurrenceDto } from './create-staff-schedule.dto';
 
 /**
  * DTO para actualizar un horario del personal.
- * Extiende de CreateStaffScheduleDto de forma parcial.
+ * Todos los campos son opcionales para permitir actualizaciones parciales.
  */
-export class UpdateStaffScheduleDto extends PartialType(
-  PickType(CreateStaffScheduleDto, [
-    'color',
-    'staffId',
-    'branchId',
-    'startTime',
-    'endTime',
-    'daysOfWeek',
-    'recurrence',
-    'exceptions'
-  ] as const)
-) {
+export class UpdateStaffScheduleDto {
   @ApiProperty({
-    description: 'Título del horario (requerido)',
-    example: 'Turno Mañana',
-    required: true
+    description: 'ID del personal al que pertenece el horario',
+    example: 'user-1234',
+    required: false,
   })
-  title!: string; // Campo obligatorio
+  @IsString()
+  @IsOptional()
+  @Transform(({ value }) => value?.trim())
+  staffId?: string;
+
+  @ApiProperty({
+    description: 'ID de la sucursal a la que pertenece el horario',
+    example: 'branch-5678',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @Transform(({ value }) => value?.trim())
+  branchId?: string;
+
+  @ApiProperty({
+    description: 'Título del horario',
+    example: 'Turno Mañana',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @Transform(({ value }) => value?.trim())
+  title?: string;
+
+  @ApiProperty({
+    description: 'Color del horario',
+    example: 'sky',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @Transform(({ value }) => value?.trim())
+  color?: string;
+
+  @ApiProperty({
+    description: 'Hora de inicio en formato HH:mm',
+    example: '08:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @Transform(({ value }) => value?.trim())
+  startTime?: string;
+
+  @ApiProperty({
+    description: 'Hora de fin en formato HH:mm',
+    example: '17:00',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  @Transform(({ value }) => value?.trim())
+  endTime?: string;
+
+  @ApiProperty({
+    description: 'Días de la semana en los que es válido el horario',
+    enum: DayOfWeek,
+    isArray: true,
+    example: [DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY],
+    required: false,
+  })
+  @IsArray()
+  @IsOptional()
+  @IsEnum(DayOfWeek, { each: true })
+  daysOfWeek?: DayOfWeek[];
+
+  @ApiProperty({
+    description: 'Configuración de recurrencia para el horario',
+    type: RecurrenceDto,
+    required: false,
+  })
+  @IsObject()
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => RecurrenceDto)
+  recurrence?: RecurrenceDto;
+
+  @ApiProperty({
+    description: 'Fechas excluidas en formato YYYY-MM-DD',
+    example: ['2024-05-01'],
+    type: [String],
+    required: false,
+  })
+  @IsOptional()
+  @IsArray()
+  @IsISO8601({ strict: false }, { each: true })
+  exceptions?: string[];
 } 

--- a/src/modules/staff-schedule/staff-schedule.module.ts
+++ b/src/modules/staff-schedule/staff-schedule.module.ts
@@ -1,12 +1,13 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { StaffScheduleService } from './services/staff-schedule.service';
 import { StaffScheduleRepository } from './repositories/staff-schedule.repository';
 import { AuditModule } from '@login/login/admin/audit/audit.module';
 import { StaffScheduleController } from './controllers/staff-schedule.controller';
 import { CreateStaffScheduleUseCase, DeleteStaffSchedulesUseCase, FindStaffSchedulesByFilterUseCase, ReactivateStaffSchedulesUseCase, UpdateStaffScheduleUseCase } from './use-cases';
-
+import { DeleteEventsByStaffScheduleUseCase } from '@calendar/calendar/event/use-cases/delete-events-by-staff-schedule.use-case';
+import { EventsModule } from '@calendar/calendar/event/events.module';
 @Module({
-    imports: [AuditModule],
+    imports: [AuditModule, forwardRef(() => EventsModule)],
     controllers: [StaffScheduleController],
     providers: [
         StaffScheduleService,
@@ -15,7 +16,8 @@ import { CreateStaffScheduleUseCase, DeleteStaffSchedulesUseCase, FindStaffSched
         UpdateStaffScheduleUseCase,
         DeleteStaffSchedulesUseCase,
         ReactivateStaffSchedulesUseCase,
-        FindStaffSchedulesByFilterUseCase
+        FindStaffSchedulesByFilterUseCase,
+        DeleteEventsByStaffScheduleUseCase,
     ],
     exports: [StaffScheduleService],
 })


### PR DESCRIPTION
- Se añadió el uso de forwardRef en los módulos de eventos y horarios del personal para resolver dependencias circulares.
- Se exportó el EventRepository desde el EventsModule.
- Se mejoró el DTO de actualización de horarios del personal, haciendo todos los campos opcionales y añadiendo validaciones.
- Se implementó la eliminación de eventos asociados al horario en el caso de uso de actualización de horarios del personal.